### PR TITLE
Add backslash in rankBy example

### DIFF
--- a/src/Ordering.elm
+++ b/src/Ordering.elm
@@ -256,11 +256,11 @@ you could use `byRank` to sort all the normal cards before the jokers like so:
     jokerCardOrdering : Ordering JokerCard
     jokerCardOrdering =
         Ordering.byRank
-            (card ->
+            (\card ->
                  case card of
                      NormalCard _ _ -> 1
                      Joker -> 2)
-            (x y ->
+            (\x y ->
                  case (x, y) of
                      (NormalCard v1 s1, NormalCard v2 s2) ->
                          suiteOrdering s1 s2


### PR DESCRIPTION
Adds two backslashes in rankBy documentation. The current example does not work, it requires backslashes to do so.