### PR TITLE
Changing "suite" to "suit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Library that makes it easier to write comparison functions in Elm.
 For instance, suppose you are defining a data type to represent
 a standard deck of cards. You might define it as:
 
-    type alias Card = { value : Value, suite : Suite }
-    type Suite = Clubs | Hearts | Diamonds | Spades
+    type alias Card = { value : Value, suit : Suit }
+    type Suit = Clubs | Hearts | Diamonds | Spades
     type Value = Two | Three | Four | Five | Six | Seven
                | Eight | Nine | Ten | Jack | Queen | King | Ace
 
@@ -16,13 +16,13 @@ With this representation, you could define an ordering for `Card` values composi
 
     cardOrdering : Ordering Card
     cardOrdering =
-        Ordering.byFieldWith suiteOrdering .suite
+        Ordering.byFieldWith suitOrdering .suit
             |> Ordering.breakTiesWith
                    (Ordering.byFieldWith valueOrdering .value)
 
 
-    suiteOrdering : Ordering Suite
-    suiteOrdering =
+    suitOrdering : Ordering Suit
+    suitOrdering =
         Ordering.explicit [Clubs, Hearts, Diamonds, Spades]
 
 

--- a/src/Ordering.elm
+++ b/src/Ordering.elm
@@ -21,8 +21,8 @@ This library makes it easy to create comparison functions for arbitary types by 
 smaller comparison functions. For instance, suppose you are defining a data type to represent
 a standard deck of cards. You might define it as:
 
-    type alias Card = { value : Value, suite : Suite }
-    type Suite = Clubs | Hearts | Diamonds | Spades
+    type alias Card = { value : Value, suit : Suit }
+    type Suit = Clubs | Hearts | Diamonds | Spades
     type Value = Two | Three | Four | Five | Six | Seven
                | Eight | Nine | Ten | Jack | Queen | King | Ace
 
@@ -33,13 +33,13 @@ With this representation, you could define an ordering for `Card` values composi
 
     cardOrdering : Ordering Card
     cardOrdering =
-        Ordering.byFieldWith suiteOrdering .suite
+        Ordering.byFieldWith suitOrdering .suit
             |> Ordering.breakTiesWith
                    (Ordering.byFieldWith valueOrdering .value)
 
 
-    suiteOrdering : Ordering Suite
-    suiteOrdering =
+    suitOrdering : Ordering Suit
+    suitOrdering =
         Ordering.explicit [Clubs, Hearts, Diamonds, Spades]
 
 
@@ -192,21 +192,21 @@ byField =
 field selected by the given function.
 
     cards =
-        [ { value = Two, suite = Spades }
-        , { value = King, suite = Hearts }
+        [ { value = Two, suit = Spades }
+        , { value = King, suit = Hearts }
         ]
 
     List.sort
         (Ordering.byFieldWith valueOrdering .value)
         cards
-        == [ { value = Two, suite = Spades }
-           , { value = King, suite = Hearts }
+        == [ { value = Two, suit = Spades }
+           , { value = King, suit = Hearts }
            ]
     List.sort
-        (Ordering.byFieldWith suiteOrdering .suite)
+        (Ordering.byFieldWith suitOrdering .suit)
         cards
-        == [ { value = King, suite = Hearts }
-           , { value = Two, suite = Spades }
+        == [ { value = King, suit = Hearts }
+           , { value = Two, suit = Spades }
            ]
 -}
 byFieldWith : Ordering b -> (a -> b) -> Ordering a
@@ -249,7 +249,7 @@ constructors for some or all of the cases take arguments. (Otherwise use `Orderi
 instead which has a simpler interface.) For instance, to make an ordering for
 a type such as:
 
-    type JokerCard = NormalCard Value Suite | Joker
+    type JokerCard = NormalCard Value Suit | Joker
 
 you could use `byRank` to sort all the normal cards before the jokers like so:
 
@@ -263,7 +263,7 @@ you could use `byRank` to sort all the normal cards before the jokers like so:
             (\x y ->
                  case (x, y) of
                      (NormalCard v1 s1, NormalCard v2 s2) ->
-                         suiteOrdering s1 s2
+                         suitOrdering s1 s2
                              |> Ordering.ifStillTiedThen
                                     (valueOrdering v1 v2)
                      _ -> Ordering.noConflicts)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -8,10 +8,10 @@ import Ordering exposing (Ordering)
 
 
 type alias Card =
-    { value : Value, suite : Suite }
+    { value : Value, suit : Suit }
 
 
-type Suite
+type Suit
     = Clubs
     | Hearts
     | Diamonds
@@ -35,12 +35,12 @@ type Value
 
 
 type JokerCard
-    = NormalCard Value Suite
+    = NormalCard Value Suit
     | Joker
 
 
-suiteOrdering : Ordering Suite
-suiteOrdering =
+suitOrdering : Ordering Suit
+suitOrdering =
     Ordering.explicit [ Clubs, Hearts, Diamonds, Spades ]
 
 
@@ -51,7 +51,7 @@ valueOrdering =
 
 cardOrdering : Ordering Card
 cardOrdering =
-    Ordering.byFieldWith suiteOrdering .suite
+    Ordering.byFieldWith suitOrdering .suit
         |> Ordering.breakTiesWith (Ordering.byFieldWith valueOrdering .value)
 
 
@@ -65,8 +65,8 @@ oneOf items =
     Fuzz.frequency (List.map (\x -> ( 1, Fuzz.constant x )) items)
 
 
-suite : Fuzzer Suite
-suite =
+suit : Fuzzer Suit
+suit =
     oneOf [ Clubs, Hearts, Diamonds, Spades ]
 
 
@@ -77,7 +77,7 @@ value =
 
 card : Fuzzer Card
 card =
-    Fuzz.map2 Card value suite
+    Fuzz.map2 Card value suit
 
 
 deck : Fuzzer (List Card)
@@ -190,18 +190,18 @@ all =
             )
         , describe "explicit"
             [ test "ordered" <|
-                \_ -> expectOrdered suiteOrdering [ Clubs, Hearts, Diamonds, Spades ]
+                \_ -> expectOrdered suitOrdering [ Clubs, Hearts, Diamonds, Spades ]
             , test "equal" <|
                 \_ ->
-                    suiteOrdering Hearts Hearts
+                    suitOrdering Hearts Hearts
                         |> Expect.equal EQ
             , test "less than" <|
                 \_ ->
-                    suiteOrdering Hearts Spades
+                    suitOrdering Hearts Spades
                         |> Expect.equal LT
             , test "greater than" <|
                 \_ ->
-                    suiteOrdering Diamonds Clubs
+                    suitOrdering Diamonds Clubs
                         |> Expect.equal GT
             , let
                 orderedValues =
@@ -313,7 +313,7 @@ all =
                         (\x y ->
                             case ( x, y ) of
                                 ( NormalCard v1 s1, NormalCard v2 s2 ) ->
-                                    suiteOrdering s1 s2
+                                    suitOrdering s1 s2
                                         |> Ordering.ifStillTiedThen (valueOrdering v1 v2)
 
                                 _ ->
@@ -330,7 +330,7 @@ all =
                 \_ ->
                     sortCards [ Card Two Spades, Card King Diamonds ]
                         |> Expect.equal [ Card King Diamonds, Card Two Spades ]
-            , test "Cards in same suite are ordered" <|
+            , test "Cards in same suit are ordered" <|
                 \_ ->
                     sortCards [ Card Ten Spades, Card Four Hearts, Card Three Spades ]
                         |> Expect.equal [ Card Four Hearts, Card Three Spades, Card Ten Spades ]


### PR DESCRIPTION
Hey, thanks for this package!

I'm building something that requires playing cards and it was funny to see the examples be completely relevant!

This pull request is just a grammar nitpick: the examples used the word "suite" instead of "suit", the latter is the appropriate one for the sets in playing cards ([see more](https://grammarist.com/usage/suit-vs-suite/)).